### PR TITLE
Cjsify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-proxy-middleware",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Simple express.js friendly json proxy middleware utility",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ interface ProxyMiddlewareOptions {
 // You _must_ register bodyParser.json() before mounting this middleware. Also,
 // it only works for JSON bodies (and not, for instance, form encoded bodies,
 // or bodies with YAML, or anything else like that).
-export default (options: ProxyMiddlewareOptions): RequestHandler => (
+module.exports = (options: ProxyMiddlewareOptions): RequestHandler => (
   req,
   res,
   next,


### PR DESCRIPTION
Previously I had need to `require('json-proxy-middleware').default` in my node projects. That's yuck.