### PR TITLE
attach req.body to error.meta.body. closes #8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (
               `returned from invoking urlHost() was not a string.`,
             meta: {
               additionalLogMessage: additionalLogMessage || '',
+              body: req.body,
             },
           },
         },
@@ -150,6 +151,7 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (
             meta: {
               additionalLogMessage: additionalLogMessage || '',
               url: `${host}${urlPath}`,
+              body: req.body,
             },
           },
         },
@@ -186,6 +188,7 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (
             meta: {
               additionalLogMessage: additionalLogMessage || '',
               url: `${host}${urlPath}`,
+              body: req.body,
             },
           },
         },


### PR DESCRIPTION
Although this is doable already with the middleware pattern it helps enhance the 'express auto error render' experience for some folks.