### PR TITLE
export pure helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-proxy-middleware",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Simple express.js friendly json proxy middleware utility",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
-'use strict';
-
 import bunyan from 'bunyan';
 import { Request, RequestHandler, Response } from 'express';
 import _pick from 'lodash/pick';
-import request from 'request';
+import request, { CoreOptions, Headers, UrlOptions } from 'request';
 import { inspect } from 'util';
 import VError from 'verror';
 
 export type UrlHost = string | ((req: Request, res: Response) => string);
 export type HeaderOption = object | ((req: Request, res: Response) => request.Headers);
+export type AddCurlHeader = boolean | ((req: Request, res: Response) => boolean);
 export type LoggerOption =
   | bunyan
   | Console
@@ -22,15 +21,20 @@ export interface ProxyMiddlewareOptions {
   headers: HeaderOption;
   logger: LoggerOption;
   urlHost: UrlHost;
+  addCurlHeader?: AddCurlHeader;
 }
 
 interface AgentOptionsRequest extends Request {
-  agentOptions: any;
+  agentOptions?: any;
 }
 
 // we use these for more accurate timing when logging
 const NS_PER_SEC: number = 1e9;
 const MS_PER_NS: number = 1e6;
+
+// Node's max header size is 80KB. We conservatively cap at 20KB.
+// https://github.com/nodejs/node/blob/8b4af64f50c5e41ce0155716f294c24ccdecad03/deps/http_parser/http_parser.h#L63
+const MAX_HEADER_SIZE: number = 20 * 1024;
 
 // by default, we intend to proxy only json responses
 const defaultHeaders: object = {
@@ -38,22 +42,25 @@ const defaultHeaders: object = {
   'Content-Type': 'application/json',
 };
 
+const createCurlRequest = (requestOptions: request.CoreOptions & request.UrlOptions) => {
+  const requestHeaders = (requestOptions.headers || {});
+  const headers = Object.keys((requestOptions.headers || {})).reduce((headersString, headerKey) => {
+    return `${headersString}-H '${headerKey}: ${requestHeaders[headerKey]}' `;
+  }, '');
+  const requestBody = JSON.stringify(requestOptions.body || {});
+  return `'${requestOptions.url}' -X ${requestOptions.method} ${headers} -d ${requestBody}`;
+};
+
 // This middleware proxies requests through Node to a backend service.
 // You _must_ register bodyParser.json() before mounting this middleware. Also,
 // it only works for JSON bodies (and not, for instance, form encoded bodies,
 // or bodies with YAML, or anything else like that).
-export default (options: ProxyMiddlewareOptions): RequestHandler => (
-  req,
-  res,
-  next,
-) => {
-  const { logger, additionalLogMessage, headers, urlHost } = options;
-  const { originalUrl, baseUrl, agentOptions } = req as AgentOptionsRequest;
-  const urlPath = originalUrl.replace(baseUrl, '');
+export default (options: ProxyMiddlewareOptions): RequestHandler => (req, res, next) => {
+  const { logger, additionalLogMessage, addCurlHeader = false } = options;
+  const canLogError = logger && logger.error && typeof logger.error === 'function';
+  const host = typeof options.urlHost === 'function' ? options.urlHost(req, res) : options.urlHost;
+  const urlPath = req.originalUrl.replace(req.baseUrl, '');
 
-  const canLogError =
-    logger && logger.error && typeof logger.error === 'function';
-  const host = typeof urlHost === 'function' ? urlHost(req, res) : urlHost;
   if (typeof host !== 'string') {
     if (canLogError) {
       let fullMsg = 'Proxy Error: PROXY_HOST_ERROR';
@@ -90,23 +97,11 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (
     return;
   }
 
-  const headersToUse: request.Headers =
-    typeof headers === 'function' ? headers(req, res) : headers || {};
-
-  const fullHeaders: request.Headers = {
-    ...defaultHeaders,
-    ...headersToUse,
-  };
-
-  const requestOptions = {
-    ...agentOptions, // https://github.com/request/request/issues/2964
-    headers: fullHeaders,
-    method: req.method,
-    url: `${host}${urlPath}`,
-    body: JSON.stringify(req.body),
-  };
-
   const canLogInfo = logger && logger.info && typeof logger.info === 'function';
+  const headers: Headers = {
+    ...defaultHeaders,
+    ...(typeof options.headers === 'function' ? options.headers(req, res) : options.headers || {}),
+  };
 
   if (canLogInfo) {
     let fullMsg = 'Proxy start.';
@@ -117,7 +112,7 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (
       {
         host,
         urlPath,
-        headers: fullHeaders,
+        headers,
         url: `${host}${urlPath}`,
         body: inspect(req.body, { maxArrayLength: 20 }),
       },
@@ -126,7 +121,24 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (
   }
 
   const startTime = process.hrtime();
+  const requestOptions: CoreOptions & UrlOptions = {
+    ...(req as AgentOptionsRequest).agentOptions, // https://github.com/request/request/issues/2964
+    method: req.method,
+    headers,
+    url: `${host}${urlPath}`,
+    body: JSON.stringify(req.body),
+  };
   const requestStream = request(requestOptions);
+
+  // If desired, set the curl header in the response headers so the client can surface it for
+  // debugging purposes.
+  const shouldAddCurlHeader = addCurlHeader && typeof addCurlHeader === 'function'
+    ? addCurlHeader(req, res)
+    : addCurlHeader;
+  const curlCommand = shouldAddCurlHeader && createCurlRequest(requestOptions);
+  if (curlCommand && curlCommand.length < MAX_HEADER_SIZE) {
+    res.setHeader('x-curl-command', curlCommand);
+  }
 
   requestStream.on('error', err => {
     if (canLogError) {


### PR DESCRIPTION
By exporting this functionality, we can allow consumers to see what the request actually ends up looking like, which is useful if, say, you wanted to serialize the request into a curlable string.

In the case of `videovillage`, we serialize the `requestOptions` and pipe it back as a header to the client, which can then display it in the event of an error. This also allows me to only send it back to authorized users (e.g. developers).