### PR TITLE
Curl c ommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ jsonProxy({
 });
 ```
 
-| property               | type                           | description                                                                                            |
-| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `additionalLogMessage` | `string` (optional)            | a message that will be appended to proxy start/end/error logging                                       |
-| `headers(req, res)`    | `object`/`function` (optional) | an object or function that returns an object with additional headers to forward on the proxied request |
-| `logger`               | logger instance (optional)     | any valid logger instance with methods `.info()` and `.error()` to be called with logging messages     |
-| `urlHost(req, res)`    | `string`/`function`            | a string or function that returns a string indicating a host to have a request proxied to              |
+| property               | type                            | description                                                                                            |
+| ---------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `additionalLogMessage` | `string` (optional)             | a message that will be appended to proxy start/end/error logging                                       |
+| `headers(req, res)`    | `object`/`function` (optional)  | an object or function that returns an object with additional headers to forward on the proxied request |
+| `logger`               | logger instance (optional)      | any valid logger instance with methods `.info()` and `.error()` to be called with logging messages     |
+| `addCurlHeader`        | `boolean`/`function` (optional) | attaches a curlCommand to your request headers for easier debugging (defaults to false)                |
+| `urlHost(req, res)`    | `string`/`function`             | a string or function that returns a string indicating a host to have a request proxied to              |
 
 ### `additionalLogMessage`
 
@@ -139,6 +140,29 @@ for debugging, such as when a proxy request started, when it ended, and how long
 took. We also log out errors in the event those occur. You can provide any kind of
 logger you prefer, as long as it has a `.info()` and `.error()` log level method to
 invoke.
+
+### `addCurlHeader`
+
+It's often useful to debug a request using a curl command. You can set this option to a boolean:
+
+```js
+router.get(
+  "/service/REST/v1/**",
+  jsonProxy({ urlHost: "https://my.service.url", addCurlHeader: true })
+);
+```
+
+Or set it conditionally:
+
+```js
+router.get(
+  "/service/REST/v1/**",
+  jsonProxy({
+    urlHost: "https://my.service.url",
+    addCurlHeader: (req, res) => req.originalUrl.includes('foo.bar'),
+  })
+);
+```
 
 ### `urlHost`
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ invoke.
 
 ### `addCurlHeader`
 
-It's often useful to debug a request using a curl command. You can set this option to a boolean:
+It's often useful to debug a request using a curl command. You will see this in
+your response headers as `headers['x-curl-command']`. You can set this option
+as a boolean:
 
 ```js
 router.get(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-proxy-middleware",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Simple express.js friendly json proxy middleware utility",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,9 @@ interface AgentOptionsRequest extends Request {
 const NS_PER_SEC: number = 1e9;
 const MS_PER_NS: number = 1e6;
 
-// Node's max header size is 80KB. We conservatively cap at 20KB.
+// Node's max header size is 80KB. We conservatively cap at 40KB.
 // https://github.com/nodejs/node/blob/8b4af64f50c5e41ce0155716f294c24ccdecad03/deps/http_parser/http_parser.h#L63
-const MAX_HEADER_SIZE: number = 20 * 1024;
+const MAX_HEADER_SIZE: number = 20 * 2048;
 
 // by default, we intend to proxy only json responses
 const defaultHeaders: object = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,10 @@ export default (options: ProxyMiddlewareOptions): RequestHandler => (req, res, n
   const shouldAddCurlHeader = addCurlHeader && typeof addCurlHeader === 'function'
     ? addCurlHeader(req, res)
     : addCurlHeader;
-  const curlCommand = shouldAddCurlHeader && createCurlRequest(requestOptions);
+
+  // Encode the curl command header to ensure it doesn't have invalid characters, otherwise
+  // request will throw an exception: https://github.com/request/request/issues/2120
+  const curlCommand = shouldAddCurlHeader && encodeURI(createCurlRequest(requestOptions));
   if (curlCommand && curlCommand.length < MAX_HEADER_SIZE) {
     res.setHeader('x-curl-command', curlCommand);
   }


### PR DESCRIPTION
Our curl command can result in a thrown exception:

https://github.com/request/request/issues/2120

So we need to encode it, and it's the responsibility of the client to decode.